### PR TITLE
a --max-cores option to limit the maximal number of instances

### DIFF
--- a/src/bun.ml
+++ b/src/bun.ml
@@ -17,7 +17,7 @@ let single_core =
   let doc = "Start only one fuzzer instance, even if more CPU cores are \
              available.  Even in this mode, the (lone) fuzzer will be invoked \
              with -S and an id; for more on implications, see the afl-fuzz \
-             parallel_fuzzing.txt docuentation." in
+             parallel_fuzzing.txt documentation." in
   Cmdliner.Arg.(value & flag & info ["s"; "single-core"] ~docv:"SINGLE_CORE" ~doc)
 
 let no_kill =


### PR DESCRIPTION
I would like to use ocaml-bun for potentially-long-running fuzzing on
a shared machine with many cores; I need to be able to restrict the
total number of cores used to ensure that I don't cause inconvenience
for other users wishing to run computations after I started my
fuzzing.
