### PR TITLE
Make bun compatible with both Dune 1.11 and 2.x

### DIFF
--- a/bun.opam
+++ b/bun.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/yomimono/ocaml-bun"
 bug-reports: "https://github.com/yomimono/ocaml-bun/issues"
 depends: [
   "ocaml" {>= "4.05"}
-  "dune" {build & >= "1.0"}
+  "dune" {build & >= "1.11"}
   "bos" {>= "0.2.0"}
   "cmdliner" {>= "1.0.0"}
   "fpath"

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 1.11)
 (name bun)

--- a/test/dune
+++ b/test/dune
@@ -10,19 +10,22 @@
  (modules long)
  (libraries crowbar))
 
+(rule
+ (target shorttest-output)
+ (locks core)
+ (deps ../src/bun.exe short.exe)
+ (action
+  (with-stdout-to
+   %{target}
+   (bash "! timeout 2s ../src/bun.exe -vv ./short.exe"))))
+
 (alias
  (name runtest)
- (deps ../src/bun.exe short.exe)
  (locks core)
  (action
   (progn
-   (with-stdout-to "shorttest-output"
-     (bash "! timeout 2s ../src/bun.exe -vv ./short.exe"))
    (bash "grep 'Crashes found!' shorttest-output")
-   (cat shorttest-output)
-  )
- )
-)
+   (cat shorttest-output))))
 
 (alias
  (name longtest)


### PR DESCRIPTION
Otherwise trying to install bun would downgrade dune to 1.11.4,
which would then fail to build my project which uses Dune 2.x.

See https://github.com/ocaml/dune/issues/2912, bun was relying on
a dune feature that was part of a breaking change in 2.0.

Move the new target (creation of file) out of the alias into a separate
rule, which then works on both old and new dune.