### PR TITLE
Update to dune 2

### DIFF
--- a/bun.opam
+++ b/bun.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/yomimono/ocaml-bun"
 bug-reports: "https://github.com/yomimono/ocaml-bun/issues"
 depends: [
   "ocaml" {>= "4.05"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "2.0"}
   "bos" {>= "0.2.0"}
   "cmdliner" {>= "1.0.0"}
   "fpath"

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,5 @@
-(lang dune 1.0)
+(lang dune 2.0)
+
 (name bun)
+
+(formatting disabled)

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (executable
  (name bun)
  (public_name bun)
- (libraries bos cmdliner fpath rresult astring lwt.unix
-            logs logs.cli logs.fmt fmt.tty fmt.cli))
+ (libraries bos cmdliner fpath rresult astring lwt.unix logs logs.cli
+   logs.fmt fmt.tty fmt.cli))

--- a/test/dune
+++ b/test/dune
@@ -15,12 +15,14 @@
  (deps ../src/bun.exe short.exe)
  (locks core)
  (action
-  (progn
-   (with-stdout-to
-    "shorttest-output"
-    (bash "! timeout 2s ../src/bun.exe -vv ./short.exe"))
-   (bash "grep 'Crashes found!' shorttest-output")
-   (cat shorttest-output))))
+  (setenv AFL_NO_AFFINITY 1
+  (setenv AFL_SKIP_CPUFREQ 1
+   (progn
+    (with-stdout-to
+      "shorttest-output"
+      (bash "! timeout 2s ../src/bun.exe -vv --max-cores=2 ./short.exe"))
+    (bash "grep 'Crashes found!' shorttest-output")
+    (cat shorttest-output))))))
 
 (rule
  (alias longtest)

--- a/test/dune
+++ b/test/dune
@@ -10,22 +10,20 @@
  (modules long)
  (libraries crowbar))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps ../src/bun.exe short.exe)
  (locks core)
  (action
   (progn
-   (with-stdout-to "shorttest-output"
-     (bash "! timeout 2s ../src/bun.exe -vv ./short.exe"))
+   (with-stdout-to
+    "shorttest-output"
+    (bash "! timeout 2s ../src/bun.exe -vv ./short.exe"))
    (bash "grep 'Crashes found!' shorttest-output")
-   (cat shorttest-output)
-  )
- )
-)
+   (cat shorttest-output))))
 
-(alias
- (name longtest)
+(rule
+ (alias longtest)
  (deps ../src/bun.exe long.exe)
  (locks core)
  (action


### PR DESCRIPTION
This is needed to support OCaml 4.12, and to test projects using dune 2:

- Ran `dune upgrade` using dune 2.8.5.
- Removed all `(modes byte exe)` lines.
- Removed `build` annotation in opam file and updated dependency constraint.

Note: I've just noticed there's also #15, which is similar to this. That version looks fine too, except that it needs the `build` annotation removed.