### PR TITLE
Remove old xmldiff pin in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 - docker
 env:
   global:
-  - PINS="bun:. xmldiff:https://github.com/yomimono/xmldiff.git#4.06-compat"
+  - PINS="bun:."
   - DISTRO="debian-stable"
   matrix:
   - PACKAGE="bun" OCAML_VERSION="4.05.0"


### PR DESCRIPTION
Making a PR to see whether this is still needed.